### PR TITLE
fix some typos in Storage

### DIFF
--- a/src/Supabase/Miso/Storage.hs
+++ b/src/Supabase/Miso/Storage.hs
@@ -17,6 +17,7 @@ module Supabase.Miso.Storage
   , moveFile
   , copyFile
   , deleteFiles
+  , createSignedUrl
   , createSignedUrls
   , createSignedUploadUrl
   , uploadToSignedUrl
@@ -86,7 +87,7 @@ getBucket args successful errorful = withSink $ \sink -> do
 -----------------------------------------------------------------------------
 -- | https://supabase.com/docs/reference/javascript/storage-listbuckets
 listBuckets
-  :: (Value -> action)
+  :: ([Value] -> action)
   -- ^ Response
   -> (MisoString -> action)
   -- ^ Error case
@@ -147,10 +148,10 @@ emptyBucket args successful errorful = withSink $ \sink -> do
 uploadFile
   :: MisoString
   -- ^ Bucket identifier
-  -> File
-  -- ^ The file to upload
   -> MisoString
   -- ^ The file name
+  -> File
+  -- ^ The file to upload
   -> Value
   -- ^ Options
   -> (Value -> action)
@@ -158,11 +159,10 @@ uploadFile
   -> (MisoString -> action)
   -- ^ Error case
   -> Effect parent model action
-uploadFile bucket file fileName options successful errorful = withSink $ \sink -> do
+uploadFile bucket fileName file options successful errorful = withSink $ \sink -> do
   successful_ <- successCallback sink errorful successful
   errorful_ <- errorCallback sink errorful
   options_ <- toJSVal options
-  bucket_ <- toJSVal bucket
   file_ <- toJSVal file
   fileName_ <- toJSVal fileName
   runSupabaseFrom "storage" bucket "upload" [fileName_, file_, options_] successful_ errorful_
@@ -173,16 +173,19 @@ downloadFile
   -- ^ Bucket identifier
   -> MisoString
   -- ^ The file name
+  -> Value
+  -- ^ Options
   -> (File -> action)
   -- ^ Response
   -> (MisoString -> action)
   -- ^ Errorful
   -> Effect parent model action
-downloadFile bucket fileName successful errorful = withSink $ \sink -> do
+downloadFile bucket fileName opts successful errorful = withSink $ \sink -> do
   successful_ <- successCallbackFile sink errorful successful
   errorful_ <- errorCallback sink errorful
-  bucket_ <- toJSVal bucket
-  runSupabaseFrom "storage" bucket "download" [fileName] successful_ errorful_
+  fileName_ <- toJSVal fileName
+  opts_ <- toJSVal opts
+  runSupabaseFrom "storage" bucket "download" [fileName_, opts_] successful_ errorful_
 -----------------------------------------------------------------------------
 -- | https://supabase.com/docs/reference/javascript/storage-from-list
 listAllFiles
@@ -208,10 +211,10 @@ listAllFiles bucket fileName options successful errorful = withSink $ \sink -> d
 replaceFile
   :: MisoString
   -- ^ Bucket identifier
-  -> File
-  -- ^ The file to upload
   -> MisoString
   -- ^ The file name
+  -> File
+  -- ^ The file to upload
   -> Value
   -- ^ Options
   -> (Value -> action)
@@ -219,11 +222,10 @@ replaceFile
   -> (MisoString -> action)
   -- ^ Error case
   -> Effect parent model action
-replaceFile bucket file fileName options successful errorful = withSink $ \sink -> do
+replaceFile bucket fileName file options successful errorful = withSink $ \sink -> do
   successful_ <- successCallback sink errorful successful
   errorful_ <- errorCallback sink errorful
   options_ <- toJSVal options
-  bucket_ <- toJSVal bucket
   file_ <- toJSVal file
   fileName_ <- toJSVal fileName
   runSupabaseFrom "storage" bucket "update" [fileName_, file_, options_] successful_ errorful_
@@ -236,17 +238,20 @@ moveFile
   -- ^ Target file
   -> MisoString
   -- ^ New file
+  -> Value
+  -- ^ Options
   -> (Value -> action)
   -- ^ Response
   -> (MisoString -> action)
   -- ^ Error case
   -> Effect parent model action
-moveFile bucket target destination successful errorful = withSink $ \sink -> do
+moveFile bucket target destination opts successful errorful = withSink $ \sink -> do
   successful_ <- successCallback sink errorful successful
   errorful_ <- errorCallback sink errorful
   target_ <- toJSVal target
   destination_ <- toJSVal destination
-  runSupabaseFrom "storage" bucket "move" [target_, destination_] successful_ errorful_
+  opts_ <- toJSVal opts
+  runSupabaseFrom "storage" bucket "move" [target_, destination_, opts_] successful_ errorful_
 -----------------------------------------------------------------------------
 -- | https://supabase.com/docs/reference/javascript/storage-from-copy
 copyFile
@@ -256,17 +261,20 @@ copyFile
   -- ^ Target file
   -> MisoString
   -- ^ New file
+  -> Value
+  -- ^ Options
   -> (Value -> action)
   -- ^ Response
   -> (MisoString -> action)
   -- ^ Error case
   -> Effect parent model action
-copyFile bucket target destination successful errorful = withSink $ \sink -> do
+copyFile bucket target destination opts successful errorful = withSink $ \sink -> do
   successful_ <- successCallback sink errorful successful
   errorful_ <- errorCallback sink errorful
   target_ <- toJSVal target
   destination_ <- toJSVal destination
-  runSupabaseFrom "storage" bucket "copy" [target_, destination_] successful_ errorful_
+  opts_ <- toJSVal opts
+  runSupabaseFrom "storage" bucket "copy" [target_, destination_, opts_] successful_ errorful_
 -----------------------------------------------------------------------------
 -- | https://supabase.com/docs/reference/javascript/storage-from-remove
 deleteFiles
@@ -284,6 +292,26 @@ deleteFiles bucket files successful errorful = withSink $ \sink -> do
   errorful_ <- errorCallback sink errorful
   files_ <- toJSVal files
   runSupabaseFrom "storage" bucket "remove" [files_] successful_ errorful_
+-----------------------------------------------------------------------------
+-- | https://supabase.com/docs/reference/javascript/storage-from-createsignedurl
+createSignedUrl
+  :: MisoString
+  -- ^ Bucket identifier
+  -> MisoString
+  -- ^ File to sign
+  -> Int
+  -- ^ Expiration time
+  -> (Value -> action)
+  -- ^ Response
+  -> (MisoString -> action)
+  -- ^ Error case
+  -> Effect parent model action
+createSignedUrl bucket file expiry successful errorful = withSink $ \sink -> do
+  successful_ <- successCallback sink errorful successful
+  errorful_ <- errorCallback sink errorful
+  file_ <- toJSVal file
+  expiry_ <- toJSVal expiry
+  runSupabaseFrom "storage" bucket "createSignedUrl" [file_, expiry_] successful_ errorful_
 -----------------------------------------------------------------------------
 -- | https://supabase.com/docs/reference/javascript/storage-from-createsignedurls
 createSignedUrls
@@ -303,7 +331,7 @@ createSignedUrls bucket files expiry successful errorful = withSink $ \sink -> d
   errorful_ <- errorCallback sink errorful
   files_ <- toJSVal files
   expiry_ <- toJSVal expiry
-  runSupabaseFrom "storage" bucket "createSignedUrl" [files_, expiry_] successful_ errorful_
+  runSupabaseFrom "storage" bucket "createSignedUrls" [files_, expiry_] successful_ errorful_
 -----------------------------------------------------------------------------
 -- | https://supabase.com/docs/reference/javascript/storage-from-createsigneduploadurl
 createSignedUploadUrl
@@ -311,16 +339,19 @@ createSignedUploadUrl
   -- ^ Bucket identifier
   -> MisoString
   -- ^ File to upload
+  -> Value
+  -- ^ Options
   -> (Value -> action)
   -- ^ Response
   -> (MisoString -> action)
   -- ^ Error case
   -> Effect parent model action
-createSignedUploadUrl bucket file successful errorful = withSink $ \sink -> do
+createSignedUploadUrl bucket file opts successful errorful = withSink $ \sink -> do
   successful_ <- successCallback sink errorful successful
   errorful_ <- errorCallback sink errorful
   file_ <- toJSVal file
-  runSupabaseFrom "storage" bucket "createSignedUploadUrl" [file_] successful_ errorful_
+  opts_ <- toJSVal opts
+  runSupabaseFrom "storage" bucket "createSignedUploadUrl" [file_, opts_] successful_ errorful_
 -----------------------------------------------------------------------------
 -- | https://supabase.com/docs/reference/javascript/storage-from-uploadtosignedurl
 uploadToSignedUrl
@@ -332,18 +363,21 @@ uploadToSignedUrl
   -- ^ Token
   -> File
   -- ^ File to upload
+  -> Value
+  -- ^ Options
   -> (Value -> action)
   -- ^ Response
   -> (MisoString -> action)
   -- ^ Error case
   -> Effect parent model action
-uploadToSignedUrl bucket fileName token file successful errorful = withSink $ \sink -> do
+uploadToSignedUrl bucket fileName token file opts successful errorful = withSink $ \sink -> do
   successful_ <- successCallback sink errorful successful
   errorful_ <- errorCallback sink errorful
   fileName_ <- toJSVal fileName
   token_ <- toJSVal token
   file_ <- toJSVal file
-  runSupabaseFrom "storage" bucket "uploadToSignedUrl" [fileName_, token_, file_] successful_ errorful_
+  opts_ <- toJSVal opts
+  runSupabaseFrom "storage" bucket "uploadToSignedUrl" [fileName_, token_, file_, opts_] successful_ errorful_
 -----------------------------------------------------------------------------
 -- | https://supabase.com/docs/reference/javascript/storage-from-getpublicurl
 getPublicUrl
@@ -351,14 +385,17 @@ getPublicUrl
   -- ^ Bucket identifier
   -> MisoString
   -- ^ File name
+  -> Value
+  -- ^ Options
   -> (Value -> action)
   -- ^ Response
   -> (MisoString -> action)
   -- ^ Error case
   -> Effect parent model action
-getPublicUrl bucket fileName successful errorful = withSink $ \sink -> do
+getPublicUrl bucket fileName opts successful errorful = withSink $ \sink -> do
   successful_ <- successCallback sink errorful successful
   errorful_ <- errorCallback sink errorful
   fileName_ <- toJSVal fileName
-  runSupabaseFrom "storage" bucket "getPublicUrl" [fileName_] successful_ errorful_
+  opts_ <- toJSVal opts
+  runSupabaseFrom "storage" bucket "getPublicUrl" [fileName_, opts_] successful_ errorful_
 -----------------------------------------------------------------------------


### PR DESCRIPTION
TODO: write a type for handling options (instead of `Value` or `BucketOptions`). Maybe something like:
```hs
newtype Opts = Opts { unOpts :: Value }
  deriving (Eq, ToJSVal)

instance Semigroup Opts where
  Opts (Aeson.Object km1) <> Opts (Aeson.Object km2) = Opts $ Aeson.Object (KM.union km1 km2)
  Opts (Aeson.Object km1) <> _ = Opts $ Aeson.Object km1
  _ <> Opts (Aeson.Object km2) = Opts $ Aeson.Object km2
  _ <> _ = mempty

instance Monoid Opts where
  mempty = Opts (Aeson.Object KM.empty)

toOpts :: ToJSON a => Aeson.Key -> a -> Opts
toOpts k v = Opts $ Aeson.Object $ KM.singleton k (toJSON v)

optsExample1 :: Opts
optsExample1 = toOpts "limit" 1  <> toOpts "search" "windsurf"
```